### PR TITLE
making mapcheckr work for panoid'd maps

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -84,7 +84,6 @@
 				<p><Badge :number="state.success" /> success</p>
 				<p><Badge changeClass :number="state.notFound" /> streetview not found</p>
 				<p><Badge changeClass :number="state.unofficial" /> unofficial</p>
-				<p><Badge changeClass :number="state.brokenLinks" /> broken links</p>
 				<p><Badge changeClass :number="state.noDescription" /> no description (potential trekker)</p>
 				<p><Badge changeClass :number="state.outOfDate" /> doesn't match date criteria</p>
 				<p v-if="settings.removeNearby"><Badge changeClass :number="state.tooClose" /> within the same ({{ settings.nearbyRadius }} m) radius</p>

--- a/src/utils/SVreq.js
+++ b/src/utils/SVreq.js
@@ -5,7 +5,7 @@ export default function SVreq(loc, settings) {
 		let callback = (res, status) => {
 			if (status != google.maps.StreetViewStatus.OK) return reject({ ...loc, reason: "sv not found" });
 			if (settings.rejectUnofficial) {
-				if (res.location.pano.length != 22) return reject({ ...loc, reason: res.copyright.substring(6) });
+				if (res.location.pano.length != 22) return reject({ ...loc, reason: "unofficial coverage"  });
 				if (settings.rejectNoDescription && !res.location.description && !res.location.shortDescription) return reject({ ...loc, reason: "no description" });
 			}
 			if (Date.parse(res.imageDate) < Date.parse(settings.fromDate) || Date.parse(res.imageDate) > Date.parse(settings.toDate))

--- a/src/utils/SVreq.js
+++ b/src/utils/SVreq.js
@@ -2,11 +2,10 @@ const SV = new google.maps.StreetViewService();
 
 export default function SVreq(loc, settings) {
 	return new Promise(async (resolve, reject) => {
-		await SV.getPanoramaByLocation(new google.maps.LatLng(loc.lat, loc.lng), settings.radius, (res, status) => {
+		let callback = (res, status) => {
 			if (status != google.maps.StreetViewStatus.OK) return reject({ ...loc, reason: "sv not found" });
 			if (settings.rejectUnofficial) {
-				if (!res.copyright.includes(" Google")) return reject({ ...loc, reason: "unofficial coverage" });
-				if (res.links.length == 0) return reject({ ...loc, reason: "no link found" });
+				if (res.location.pano.length != 22) return reject({ ...loc, reason: res.copyright.substring(6) });
 				if (settings.rejectNoDescription && !res.location.description && !res.location.shortDescription) return reject({ ...loc, reason: "no description" });
 			}
 			if (Date.parse(res.imageDate) < Date.parse(settings.fromDate) || Date.parse(res.imageDate) > Date.parse(settings.toDate))
@@ -22,7 +21,13 @@ export default function SVreq(loc, settings) {
 				loc.lng = res.location.latLng.lng();
 			}
 			resolve(loc);
-		}).catch((e) => reject({ loc, reason: e.message }));
+		}
+		if(!loc.panoId){
+			await SV.getPanoramaByLocation(new google.maps.LatLng(loc.lat, loc.lng), settings.radius, callback).catch((e) => reject({ loc, reason: e.message }));
+		}
+		else{
+			await SV.getPanoramaById(loc.panoId, callback).catch((e) => reject({ loc, reason: e.message }));
+		}
 	});
 }
 


### PR DESCRIPTION
A small change I made to make mapcheckr work properly for panoid'd maps. I decided to remove the test for broken links since I came across a location which was rejected despite being official while testing, and checking for the length of the panoID should suffice. That said, if you think that checking links is necessary, it can be readded of course.