### PR TITLE
option to reject gen 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,639 @@
 {
 	"name": "mapcheckr",
 	"version": "0.0.0",
-	"lockfileVersion": 1,
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "mapcheckr",
+			"version": "0.0.0",
+			"dependencies": {
+				"get-country-code": "git+https://github.com/tzhf/get-country-code.git",
+				"vue": "^3.2.16"
+			},
+			"devDependencies": {
+				"@vitejs/plugin-vue": "^1.9.3",
+				"vite": "^2.6.4"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+			"integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@turf/boolean-point-in-polygon": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz",
+			"integrity": "sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/@turf/helpers": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+			"integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/@turf/invariant": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+			"integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/@vitejs/plugin-vue": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.9.3.tgz",
+			"integrity": "sha512-yW6H/q+4Mc2PcVjSOelcsMrg/k15DnMUz8jyCFsI04emc3aLwo4AoofUfGnjHUkgirrDxSJLVqQVGhonQ3yykA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"vite": "^2.5.10"
+			}
+		},
+		"node_modules/@vue/compiler-core": {
+			"version": "3.2.20",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.20.tgz",
+			"integrity": "sha512-vcEXlKXoPwBXFP5aUTHN9GTZaDfwCofa9Yu9bbW2C5O/QSa9Esdt7OG4+0RRd3EHEMxUvEdj4RZrd/KpQeiJbA==",
+			"dependencies": {
+				"@babel/parser": "^7.15.0",
+				"@vue/shared": "3.2.20",
+				"estree-walker": "^2.0.2",
+				"source-map": "^0.6.1"
+			}
+		},
+		"node_modules/@vue/compiler-dom": {
+			"version": "3.2.20",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.20.tgz",
+			"integrity": "sha512-QnI77ec/JtV7R0YBbcVayYTDCRcI9OCbxiUQK6izVyqQO0658n0zQuoNwe+bYgtqnvGAIqTR3FShTd5y4oOjdg==",
+			"dependencies": {
+				"@vue/compiler-core": "3.2.20",
+				"@vue/shared": "3.2.20"
+			}
+		},
+		"node_modules/@vue/compiler-sfc": {
+			"version": "3.2.20",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.20.tgz",
+			"integrity": "sha512-03aZo+6tQKiFLfunHKSPZvdK4Jsn/ftRCyaro8AQIWkuxJbvSosbKK6HTTn+D2c3nPScG155akJoxKENw7rftQ==",
+			"dependencies": {
+				"@babel/parser": "^7.15.0",
+				"@vue/compiler-core": "3.2.20",
+				"@vue/compiler-dom": "3.2.20",
+				"@vue/compiler-ssr": "3.2.20",
+				"@vue/ref-transform": "3.2.20",
+				"@vue/shared": "3.2.20",
+				"estree-walker": "^2.0.2",
+				"magic-string": "^0.25.7",
+				"postcss": "^8.1.10",
+				"source-map": "^0.6.1"
+			}
+		},
+		"node_modules/@vue/compiler-ssr": {
+			"version": "3.2.20",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.20.tgz",
+			"integrity": "sha512-rzzVVYivm+EjbfiGQvNeyiYZWzr6Hkej97RZLZvcumacQlnKv9176Xo9rRyeWwFbBlxmtNdrVMslRXtipMXk2w==",
+			"dependencies": {
+				"@vue/compiler-dom": "3.2.20",
+				"@vue/shared": "3.2.20"
+			}
+		},
+		"node_modules/@vue/reactivity": {
+			"version": "3.2.20",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.20.tgz",
+			"integrity": "sha512-nSmoLojUTk+H8HNTAkrUduB4+yIUBK2HPihJo2uXVSH4Spry6oqN6lFzE5zpLK+F27Sja+UqR9R1+/kIOsHV5w==",
+			"dependencies": {
+				"@vue/shared": "3.2.20"
+			}
+		},
+		"node_modules/@vue/ref-transform": {
+			"version": "3.2.20",
+			"resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.20.tgz",
+			"integrity": "sha512-Y42d3PGlYZ1lXcF3dbd3+qU/C/a3wYEZ949fyOI5ptzkjDWlkfU6vn74fmOjsLjEcjs10BXK2qO99FqQIK2r1Q==",
+			"dependencies": {
+				"@babel/parser": "^7.15.0",
+				"@vue/compiler-core": "3.2.20",
+				"@vue/shared": "3.2.20",
+				"estree-walker": "^2.0.2",
+				"magic-string": "^0.25.7"
+			}
+		},
+		"node_modules/@vue/runtime-core": {
+			"version": "3.2.20",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.20.tgz",
+			"integrity": "sha512-d1xfUGhZPfiZzAN7SatStD4vRtT8deJSXib2+Cz3x0brjMWKxe32asQc154FF1E2fFgMCHtnfd4A90bQEzV4GQ==",
+			"dependencies": {
+				"@vue/reactivity": "3.2.20",
+				"@vue/shared": "3.2.20"
+			}
+		},
+		"node_modules/@vue/runtime-dom": {
+			"version": "3.2.20",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.20.tgz",
+			"integrity": "sha512-4TCvZMLhESWCFHFYgqN4QmMA/onnINAlUovhopjlS8ST27G1A8Z0tyxPzLoXLa+b5JrOpbMPheEMPvdKExTJig==",
+			"dependencies": {
+				"@vue/runtime-core": "3.2.20",
+				"@vue/shared": "3.2.20",
+				"csstype": "^2.6.8"
+			}
+		},
+		"node_modules/@vue/server-renderer": {
+			"version": "3.2.20",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.20.tgz",
+			"integrity": "sha512-viIbZGep9XabnrRcaxWIi00cOh1x21QYm2upIL5W0zqzTJ54VdTzpI+zi1osNp+VfRQDTHpV2U7H3Kn4ljYJvg==",
+			"dependencies": {
+				"@vue/compiler-ssr": "3.2.20",
+				"@vue/shared": "3.2.20"
+			},
+			"peerDependencies": {
+				"vue": "3.2.20"
+			}
+		},
+		"node_modules/@vue/shared": {
+			"version": "3.2.20",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.20.tgz",
+			"integrity": "sha512-FbpX+hD5BvXCQerEYO7jtAGHlhAkhTQ4KIV73kmLWNlawWhTiVuQxizgVb0BOkX5oG9cIRZ42EG++d/k/Efp0w=="
+		},
+		"node_modules/csstype": {
+			"version": "2.6.18",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
+			"integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
+		},
+		"node_modules/esbuild": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.8.tgz",
+			"integrity": "sha512-A4af7G7YZLfG5OnARJRMtlpEsCkq/zHZQXewgPA864l9D6VjjbH1SuFYK/OSV6BtHwDGkdwyRrX0qQFLnMfUcw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"optionalDependencies": {
+				"esbuild-android-arm64": "0.13.8",
+				"esbuild-darwin-64": "0.13.8",
+				"esbuild-darwin-arm64": "0.13.8",
+				"esbuild-freebsd-64": "0.13.8",
+				"esbuild-freebsd-arm64": "0.13.8",
+				"esbuild-linux-32": "0.13.8",
+				"esbuild-linux-64": "0.13.8",
+				"esbuild-linux-arm": "0.13.8",
+				"esbuild-linux-arm64": "0.13.8",
+				"esbuild-linux-mips64le": "0.13.8",
+				"esbuild-linux-ppc64le": "0.13.8",
+				"esbuild-netbsd-64": "0.13.8",
+				"esbuild-openbsd-64": "0.13.8",
+				"esbuild-sunos-64": "0.13.8",
+				"esbuild-windows-32": "0.13.8",
+				"esbuild-windows-64": "0.13.8",
+				"esbuild-windows-arm64": "0.13.8"
+			}
+		},
+		"node_modules/esbuild-android-arm64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.8.tgz",
+			"integrity": "sha512-AilbChndywpk7CdKkNSZ9klxl+9MboLctXd9LwLo3b0dawmOF/i/t2U5d8LM6SbT1Xw36F8yngSUPrd8yPs2RA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/esbuild-darwin-64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.8.tgz",
+			"integrity": "sha512-b6sdiT84zV5LVaoF+UoMVGJzR/iE2vNUfUDfFQGrm4LBwM/PWXweKpuu6RD9mcyCq18cLxkP6w/LD/w9DtX3ng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/esbuild-darwin-arm64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.8.tgz",
+			"integrity": "sha512-R8YuPiiJayuJJRUBG4H0VwkEKo6AvhJs2m7Tl0JaIer3u1FHHXwGhMxjJDmK+kXwTFPriSysPvcobXC/UrrZCQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/esbuild-freebsd-64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.8.tgz",
+			"integrity": "sha512-zBn6urrn8FnKC+YSgDxdof9jhPCeU8kR/qaamlV4gI8R3KUaUK162WYM7UyFVAlj9N0MyD3AtB+hltzu4cysTw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/esbuild-freebsd-arm64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.8.tgz",
+			"integrity": "sha512-pWW2slN7lGlkx0MOEBoUGwRX5UgSCLq3dy2c8RIOpiHtA87xAUpDBvZK10MykbT+aMfXc0NI2lu1X+6kI34xng==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/esbuild-linux-32": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.8.tgz",
+			"integrity": "sha512-T0I0ueeKVO/Is0CAeSEOG9s2jeNNb8jrrMwG9QBIm3UU18MRB60ERgkS2uV3fZ1vP2F8i3Z2e3Zju4lg9dhVmw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.8.tgz",
+			"integrity": "sha512-Bm8SYmFtvfDCIu9sjKppFXzRXn2BVpuCinU1ChTuMtdKI/7aPpXIrkqBNOgPTOQO9AylJJc1Zw6EvtKORhn64w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-arm": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.8.tgz",
+			"integrity": "sha512-4/HfcC40LJ4GPyboHA+db0jpFarTB628D1ifU+/5bunIgY+t6mHkJWyxWxAAE8wl/ZIuRYB9RJFdYpu1AXGPdg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-arm64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.8.tgz",
+			"integrity": "sha512-X4pWZ+SL+FJ09chWFgRNO3F+YtvAQRcWh0uxKqZSWKiWodAB20flsW/OWFYLXBKiVCTeoGMvENZS/GeVac7+tQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-mips64le": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.8.tgz",
+			"integrity": "sha512-o7e0D+sqHKT31v+mwFircJFjwSKVd2nbkHEn4l9xQ1hLR+Bv8rnt3HqlblY3+sBdlrOTGSwz0ReROlKUMJyldA==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-ppc64le": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.8.tgz",
+			"integrity": "sha512-eZSQ0ERsWkukJp2px/UWJHVNuy0lMoz/HZcRWAbB6reoaBw7S9vMzYNUnflfL3XA6WDs+dZn3ekHE4Y2uWLGig==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-netbsd-64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.8.tgz",
+			"integrity": "sha512-gZX4kP7gVvOrvX0ZwgHmbuHczQUwqYppxqtoyC7VNd80t5nBHOFXVhWo2Ad/Lms0E8b+wwgI/WjZFTCpUHOg9Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			]
+		},
+		"node_modules/esbuild-openbsd-64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.8.tgz",
+			"integrity": "sha512-afzza308X4WmcebexbTzAgfEWt9MUkdTvwIa8xOu4CM2qGbl2LanqEl8/LUs8jh6Gqw6WsicEK52GPrS9wvkcw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/esbuild-sunos-64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.8.tgz",
+			"integrity": "sha512-mWPZibmBbuMKD+LDN23LGcOZ2EawMYBONMXXHmbuxeT0XxCNwadbCVwUQ/2p5Dp5Kvf6mhrlIffcnWOiCBpiVw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			]
+		},
+		"node_modules/esbuild-windows-32": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.8.tgz",
+			"integrity": "sha512-QsZ1HnWIcnIEApETZWw8HlOhDSWqdZX2SylU7IzGxOYyVcX7QI06ety/aDcn437mwyO7Ph4RrbhB+2ntM8kX8A==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/esbuild-windows-64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.8.tgz",
+			"integrity": "sha512-76Fb57B9eE/JmJi1QmUW0tRLQZfGo0it+JeYoCDTSlbTn7LV44ecOHIMJSSgZADUtRMWT9z0Kz186bnaB3amSg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/esbuild-windows-arm64": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.8.tgz",
+			"integrity": "sha512-HW6Mtq5eTudllxY2YgT62MrVcn7oq2o8TAoAvDUhyiEmRmDY8tPwAhb1vxw5/cdkbukM3KdMYtksnUhF/ekWeg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"node_modules/get-country-code": {
+			"version": "1.0.0",
+			"resolved": "git+ssh://git@github.com/tzhf/get-country-code.git#d92faa003efea011aa1a08bd5204765e8540dc21",
+			"integrity": "sha512-738RIzFgkpIZCxtTg4F70QTLNAOl6yU4fcdTMNhCgRe66l5rg031dB0pfA8bmSu3f1xVL5BZ67leE3tnjC7xgQ==",
+			"license": "ISC",
+			"dependencies": {
+				"@turf/boolean-point-in-polygon": "^6.5.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+			"integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+			"dev": true,
+			"dependencies": {
+				"has": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.25.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"dependencies": {
+				"sourcemap-codec": "^1.4.4"
+			}
+		},
+		"node_modules/nanoid": {
+			"version": "3.1.30",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+			"integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true
+		},
+		"node_modules/picocolors": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
+		},
+		"node_modules/postcss": {
+			"version": "8.3.9",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.9.tgz",
+			"integrity": "sha512-f/ZFyAKh9Dnqytx5X62jgjhhzttjZS7hMsohcI7HEI5tjELX/HxCy3EFhsRxyzGvrzFF+82XPvCS8T9TFleVJw==",
+			"dependencies": {
+				"nanoid": "^3.1.28",
+				"picocolors": "^0.2.1",
+				"source-map-js": "^0.6.2"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.2.0",
+				"path-parse": "^1.0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "2.58.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.58.0.tgz",
+			"integrity": "sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==",
+			"dev": true,
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+			"integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+		},
+		"node_modules/vite": {
+			"version": "2.6.10",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.6.10.tgz",
+			"integrity": "sha512-XbevwpDJMs3lKiGEj0UQScsOCpwHIjFgfzPnFVkPgnxsF9oPv1uGyckLg58XkXv6LnO46KN9yZqJzINFmAxtUg==",
+			"dev": true,
+			"dependencies": {
+				"esbuild": "^0.13.2",
+				"postcss": "^8.3.8",
+				"resolve": "^1.20.0",
+				"rollup": "^2.57.0"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": ">=12.2.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			},
+			"peerDependencies": {
+				"less": "*",
+				"sass": "*",
+				"stylus": "*"
+			},
+			"peerDependenciesMeta": {
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vue": {
+			"version": "3.2.20",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.2.20.tgz",
+			"integrity": "sha512-81JjEP4OGk9oO8+CU0h2nFPGgJBm9mNa3kdCX2k6FuRdrWrC+CNe+tOnuIeTg8EWwQuI+wwdra5Q7vSzp7p4Iw==",
+			"dependencies": {
+				"@vue/compiler-dom": "3.2.20",
+				"@vue/compiler-sfc": "3.2.20",
+				"@vue/runtime-dom": "3.2.20",
+				"@vue/server-renderer": "3.2.20",
+				"@vue/shared": "3.2.20"
+			}
+		}
+	},
 	"dependencies": {
 		"@babel/parser": {
 			"version": "7.15.8",
@@ -35,7 +666,8 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.9.3.tgz",
 			"integrity": "sha512-yW6H/q+4Mc2PcVjSOelcsMrg/k15DnMUz8jyCFsI04emc3aLwo4AoofUfGnjHUkgirrDxSJLVqQVGhonQ3yykA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@vue/compiler-core": {
 			"version": "3.2.20",
@@ -304,8 +936,8 @@
 			"dev": true
 		},
 		"get-country-code": {
-			"version": "git+https://github.com/tzhf/get-country-code.git#d92faa003efea011aa1a08bd5204765e8540dc21",
-			"from": "git+https://github.com/tzhf/get-country-code.git",
+			"version": "git+ssh://git@github.com/tzhf/get-country-code.git#d92faa003efea011aa1a08bd5204765e8540dc21",
+			"from": "get-country-code@git+https://github.com/tzhf/get-country-code.git",
 			"requires": {
 				"@turf/boolean-point-in-polygon": "^6.5.0"
 			}

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,6 +39,9 @@
 					<hr />
 				</div>
 
+				<Checkbox v-model:checked="settings.rejectGen1" label="Reject gen 1 coverage" />
+				<hr />
+
 				<Checkbox v-model:checked="settings.fixMisplaced" label="Fix misplaced locations" optText="Some of your locations might slightly change" />
 				<hr />
 
@@ -85,6 +88,7 @@
 				<p><Badge changeClass :number="state.notFound" /> streetview not found</p>
 				<p><Badge changeClass :number="state.unofficial" /> unofficial</p>
 				<p><Badge changeClass :number="state.noDescription" /> no description (potential trekker)</p>
+				<p><Badge changeClass :number="state.gen1" /> blurry gen 1</p>
 				<p><Badge changeClass :number="state.outOfDate" /> doesn't match date criteria</p>
 				<p v-if="settings.removeNearby"><Badge changeClass :number="state.tooClose" /> within the same ({{ settings.nearbyRadius }} m) radius</p>
 			</div>
@@ -137,6 +141,7 @@ const settings = reactive({
 	radius: 50,
 	rejectUnofficial: true,
 	rejectNoDescription: false,
+	rejectGen1: true,
 	fixMisplaced: false,
 	adjustHeading: true,
 	headingDeviation: 0,
@@ -157,6 +162,7 @@ const initialState = {
 	notFound: 0,
 	unofficial: 0,
 	noDescription: 0,
+	gen1: 0,
 	brokenLinks: 0,
 	outOfDate: 0,
 	tooClose: 0,
@@ -230,6 +236,9 @@ const start = async () => {
 						break;
 					case "no description":
 						state.noDescription++;
+						break;
+					case "blurry gen 1":
+						state.gen1++;
 						break;
 					case "no link found":
 						state.brokenLinks++;

--- a/src/utils/SVreq.js
+++ b/src/utils/SVreq.js
@@ -5,8 +5,11 @@ export default function SVreq(loc, settings) {
 		let callback = (res, status) => {
 			if (status != google.maps.StreetViewStatus.OK) return reject({ ...loc, reason: "sv not found" });
 			if (settings.rejectUnofficial) {
-				if (res.location.pano.length != 22) return reject({ ...loc, reason: "unofficial coverage"  });
+				if (res.location.pano.length != 22) return reject({ ...loc, reason: "unofficial coverage" });
 				if (settings.rejectNoDescription && !res.location.description && !res.location.shortDescription) return reject({ ...loc, reason: "no description" });
+			}
+			if (settings.rejectGen1 && res.tiles.worldSize.height === 1664) {
+				return reject({ ...loc, reason: "blurry gen 1" });
 			}
 			if (Date.parse(res.imageDate) < Date.parse(settings.fromDate) || Date.parse(res.imageDate) > Date.parse(settings.toDate))
 				return reject({ ...loc, reason: "out of date" });


### PR DESCRIPTION
nur shared this way of detecting camera gens in the street view discord: https://discord.com/channels/747030604897452130/789933044525039636/952666359282667600

> I'm not sure if this was known, but you can somewhat determine what generation a pano is with this API.
> Gen 1 - `["Data"]["image_width"] === "3328" && ["Data"]["image_height"] === "1664"`

that data is also available on panorama objects from the street view service api.

![image](https://user-images.githubusercontent.com/100017889/160282877-5b2963b6-df5d-4b65-9558-05c45dad3050.png)
