### PR TITLE
Changed option for Official Coverage only

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -73,6 +73,14 @@
                         />
                         <hr />
                     </div>
+                    <div v-if="settings.rejectUnofficial">
+                        <Checkbox
+                            v-model:checked="settings.changeToOfficial"
+                            label="Change unofficial to official"
+                            optText="Change unofficial locations to official within the radius."
+                        />
+                        <hr />
+                    </div>
 
                     <Checkbox
                         @change="settings.rejectNoLinks ? (settings.rejectNoLinksIfNoHeading = true) : true"

--- a/src/utils/SVreq.js
+++ b/src/utils/SVreq.js
@@ -7,7 +7,7 @@ export default function SVreq(loc, settings) {
                 let returnLoc = await SV.getPanorama({
                     location: {lat: loc.lat, lng: loc.lng},
                     preference: google.maps.StreetViewPreference.NEAREST, // Set the preference
-                    source: google.maps.StreetViewSource.OUTDOOR, // Get outdoor panoramas
+                    sources: [google.maps.StreetViewSource.GOOGLE], // Only search official panoramas
                     radius: settings.radius // Search within a 5000-meter radius
                   },checkPano).catch((e) =>
                     reject({ loc, reason: e.message })

--- a/src/utils/SVreq.js
+++ b/src/utils/SVreq.js
@@ -3,7 +3,7 @@ const SV = new google.maps.StreetViewService();
 export default function SVreq(loc, settings) {
     return new Promise(async (resolve, reject) => {
         if (!loc.panoId) {
-            if(settings.changeToOfficial) {
+            if(settings.changeToOfficial && settings.rejectUnofficial) {
                 let returnLoc = await SV.getPanorama({
                     location: {lat: loc.lat, lng: loc.lng},
                     preference: google.maps.StreetViewPreference.NEAREST, // Set the preference

--- a/src/utils/SVreq.js
+++ b/src/utils/SVreq.js
@@ -3,9 +3,30 @@ const SV = new google.maps.StreetViewService();
 export default function SVreq(loc, settings) {
     return new Promise(async (resolve, reject) => {
         if (!loc.panoId) {
-            await SV.getPanoramaByLocation(new google.maps.LatLng(loc.lat, loc.lng), settings.radius, checkPano).catch((e) =>
-                reject({ loc, reason: e.message })
-            );
+            if(settings.changeToOfficial) {
+                let returnLoc = await SV.getPanorama({
+                    location: {lat: loc.lat, lng: loc.lng},
+                    preference: google.maps.StreetViewPreference.NEAREST, // Set the preference
+                    source: google.maps.StreetViewSource.OUTDOOR, // Get outdoor panoramas
+                    radius: settings.radius // Search within a 5000-meter radius
+                  },checkPano).catch((e) =>
+                    reject({ loc, reason: e.message })
+                );
+                if(returnLoc) {
+                    loc.panoId = returnLoc.data.location.pano;
+                    loc.lat = returnLoc.data.location.latLng.lat();
+                    loc.lng = returnLoc.data.location.latLng.lng();
+                    return resolve(loc);
+                } else {
+                    await SV.getPanoramaByLocation(new google.maps.LatLng(loc.lat, loc.lng), settings.radius, checkPano).catch((e) =>
+                        reject({ loc, reason: e.message })
+                    );
+                }
+            } else {
+                await SV.getPanoramaByLocation(new google.maps.LatLng(loc.lat, loc.lng), settings.radius, checkPano).catch((e) =>
+                    reject({ loc, reason: e.message })
+                );
+            }
         } else {
             await SV.getPanoramaById(loc.panoId, checkPano).catch((e) => reject({ loc, reason: e.message }));
         }


### PR DESCRIPTION
[](url)Earlier an issue occured when there was an unofficial coverage closer to the lat/lng then the next official one, that caused lots of streetview not to be found.

This is now taken care of in this commit. Optionally on ticking the changeToOfficial checkbox the lat/lng & panoId is overwritten with official Location values.



This File was used for testing purposes:

[HardRockCafe.json](https://github.com/user-attachments/files/18220490/HardRockCafe.json)

These settings were used. Only difference is the tagging of the _Change unofficial to official_ Checkbox.

![1](https://github.com/user-attachments/assets/2fb72f30-49c6-4b0e-a3df-6731df60d57f)

These are the changes in results:

![2](https://github.com/user-attachments/assets/c31a4970-7503-48a7-b673-6564f81cb578)

If you have any questions please let me know on dc!

Vinz